### PR TITLE
Replace deprecated typing.Dict/List with builtin dict/list

### DIFF
--- a/benchmark_orchestrators/async_optimized.py
+++ b/benchmark_orchestrators/async_optimized.py
@@ -9,7 +9,7 @@ import json
 import os
 import time
 from collections import Counter
-from typing import Any, Dict, List
+from typing import Any
 
 from pipeline_optimization.tasks.filter_input_task import filter_input
 from pipeline_optimization.tasks.find_anagrams_task import find_anagrams
@@ -37,7 +37,7 @@ class TaskOrchestrator:
         # Semaphore to limit concurrent word processing
         self._semaphore = asyncio.Semaphore(concurrency)
 
-    async def process_text(self, text_input: str) -> Dict[str, Any]:
+    async def process_text(self, text_input: str) -> dict[str, Any]:
         """
         Process text input asynchronously, finding anagrams concurrently.
         """
@@ -60,7 +60,7 @@ class TaskOrchestrator:
             unique_words = list(set(words))
 
             # Launch concurrent word tasks
-            tasks: List[asyncio.Task] = []
+            tasks: list[asyncio.Task] = []
             for word in unique_words:
                 tasks.append(asyncio.create_task(self._process_word(word)))
 
@@ -85,7 +85,7 @@ class TaskOrchestrator:
                 "error": str(e),
             }
 
-    async def _process_word(self, word: str) -> List[str]:
+    async def _process_word(self, word: str) -> list[str]:
         """
         Find anagrams for a single word with retry and concurrency control.
         """

--- a/benchmark_orchestrators/inefficient_orchestrator.py
+++ b/benchmark_orchestrators/inefficient_orchestrator.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Any, Dict, List
+from typing import Any
 
 from pipeline_optimization.tasks.filter_input_task import filter_input
 from pipeline_optimization.tasks.find_anagrams_task import find_anagrams
@@ -34,7 +34,7 @@ class TaskOrchestrator:
         with open("src/pipeline_optimization/resources/english_dictionary.json") as f:
             self.dictionary = json.load(f)
 
-    async def process_text(self, text_input: str) -> Dict[str, Any]:
+    async def process_text(self, text_input: str) -> dict[str, Any]:
         """
         Process the input text through the pipeline, finding anagrams and
         counting occurrences.
@@ -61,7 +61,7 @@ class TaskOrchestrator:
 
         # INEFFICIENCY: Sequential processing of words
         # This could be parallelized to improve performance
-        all_anagrams: List[str] = []
+        all_anagrams: list[str] = []
         for word in words:
             # INEFFICIENCY: No caching of anagram results for repeated words
             print(f"Finding anagrams for {word}")
@@ -70,7 +70,7 @@ class TaskOrchestrator:
 
         # INEFFICIENCY: Inefficient counting algorithm
         # Could use Counter from collections instead
-        anagram_counts: Dict[str, int] = {}
+        anagram_counts: dict[str, int] = {}
         for anagram in all_anagrams:
             # INEFFICIENCY: Repeated dictionary lookups
             if anagram not in anagram_counts:

--- a/benchmark_orchestrators/memory_optimized.py
+++ b/benchmark_orchestrators/memory_optimized.py
@@ -16,7 +16,7 @@ import gc
 import json
 import time
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, List
+from typing import Any, Generator
 
 from pipeline_optimization.tasks.filter_input_task import filter_input
 from pipeline_optimization.tasks.find_anagrams_task import find_anagrams
@@ -31,7 +31,7 @@ DICTIONARY_PATH = "src/pipeline_optimization/resources/english_dictionary.json"
 class WordSet:
     __slots__ = ("words",)
 
-    def __init__(self, words: List[str] = None):
+    def __init__(self, words: list[str] = None):
         self.words = words or []
 
 
@@ -91,7 +91,7 @@ class TaskOrchestrator:
         # Force garbage collection on startup to start with minimal footprint
         gc.collect()
 
-    def process_text(self, text_input: str) -> Dict[str, Any]:
+    def process_text(self, text_input: str) -> dict[str, Any]:
         """
         Process text through the pipeline with minimal memory footprint.
 
@@ -156,7 +156,7 @@ class TaskOrchestrator:
                 # Always do an aggressive garbage collection to release memory
                 gc.collect(2)  # Use generation 2 collection for more thorough cleanup
 
-    def _run_memory_efficient_pipeline(self, text_input: str) -> Dict[str, int]:
+    def _run_memory_efficient_pipeline(self, text_input: str) -> dict[str, int]:
         """
         Run the pipeline with minimal memory usage.
 
@@ -245,7 +245,7 @@ class TaskOrchestrator:
             # Return empty result
             return {}
 
-    def _find_anagrams_minimal_memory(self, word: str) -> List[str]:
+    def _find_anagrams_minimal_memory(self, word: str) -> list[str]:
         """
         Find anagrams for a word with minimal memory usage.
 
@@ -274,8 +274,8 @@ class TaskOrchestrator:
 
     @staticmethod
     def _chunk_generator(
-        items: List[str], chunk_size: int
-    ) -> Generator[List[str], None, None]:
+        items: list[str], chunk_size: int
+    ) -> Generator[list[str], None, None]:
         """
         Create a generator that yields chunks of an iterable.
 

--- a/benchmark_orchestrators/throughput_optimized.py
+++ b/benchmark_orchestrators/throughput_optimized.py
@@ -9,7 +9,7 @@ import json
 import os
 import time
 from collections import Counter
-from typing import Any, Dict, List
+from typing import Any
 
 from pipeline_optimization.tasks.filter_input_task import filter_input
 from pipeline_optimization.tasks.find_anagrams_task import find_anagrams
@@ -37,7 +37,7 @@ class TaskOrchestrator:
         # Semaphore to limit concurrent word processing
         self._semaphore = asyncio.Semaphore(concurrency)
 
-    async def process_text(self, text_input: str) -> Dict[str, Any]:
+    async def process_text(self, text_input: str) -> dict[str, Any]:
         """
         Process text input asynchronously, finding anagrams concurrently to maximize throughput.
         """
@@ -60,7 +60,7 @@ class TaskOrchestrator:
             unique_words = list(set(words))
 
             # Launch concurrent anagram tasks
-            tasks: List[asyncio.Task] = []
+            tasks: list[asyncio.Task] = []
             for word in unique_words:
                 tasks.append(asyncio.create_task(self._process_word(word)))
 
@@ -85,7 +85,7 @@ class TaskOrchestrator:
                 "error": str(e),
             }
 
-    async def _process_word(self, word: str) -> List[str]:
+    async def _process_word(self, word: str) -> list[str]:
         """
         Find anagrams for a single word with retry and concurrency control.
         """

--- a/example_solution.py
+++ b/example_solution.py
@@ -12,7 +12,7 @@ import logging
 import time
 from collections import Counter
 from functools import lru_cache
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 from pipeline_optimization.tasks.filter_input_task import filter_input
 from pipeline_optimization.tasks.find_anagrams_task import find_anagrams
@@ -57,9 +57,9 @@ class OptimizedOrchestrator:
         self.initial_backoff = initial_backoff
 
         # In-memory cache for anagrams
-        self.anagram_cache: Dict[str, List[str]] = {}
+        self.anagram_cache: dict[str, list[str]] = {}
 
-    async def process_text(self, text_input: str) -> Dict[str, Any]:
+    async def process_text(self, text_input: str) -> dict[str, Any]:
         """
         Process the input text through the pipeline, finding anagrams and
         counting occurrences.
@@ -150,7 +150,7 @@ class OptimizedOrchestrator:
                 backoff *= 2
 
     @lru_cache(maxsize=1000)
-    async def _find_anagrams_cached(self, word: str) -> List[str]:
+    async def _find_anagrams_cached(self, word: str) -> list[str]:
         """
         Find anagrams for a word with caching and retry logic.
 
@@ -164,7 +164,7 @@ class OptimizedOrchestrator:
             task=find_anagrams, input_data=word, task_name=f"find_anagrams({word})"
         )
 
-    async def _process_words_concurrently(self, words: List[str]) -> List[str]:
+    async def _process_words_concurrently(self, words: list[str]) -> list[str]:
         """
         Process words concurrently to find anagrams.
 
@@ -183,7 +183,7 @@ class OptimizedOrchestrator:
         # Process words concurrently with a bounded semaphore to limit concurrency
         semaphore = asyncio.Semaphore(self.max_workers)
 
-        async def process_word(word: str) -> List[str]:
+        async def process_word(word: str) -> list[str]:
             async with semaphore:
                 return await self._find_anagrams_cached(word)
 

--- a/src/pipeline_optimization/benchmarks/benchmarker.py
+++ b/src/pipeline_optimization/benchmarks/benchmarker.py
@@ -4,7 +4,7 @@ import json
 import statistics
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any
 
 from pipeline_optimization.benchmarks.metrics import MetricsCollector
 from pipeline_optimization.orchestrator import TaskOrchestrator
@@ -17,9 +17,9 @@ class BenchmarkResult:
     test_case: str
     iterations: int
     successful_iterations: int
-    execution_times_ms: List[float] = field(default_factory=list)
-    errors: List[Exception] = field(default_factory=list)
-    metrics_reports: List[Dict[str, Any]] = field(default_factory=list)
+    execution_times_ms: list[float] = field(default_factory=list)
+    errors: list[Exception] = field(default_factory=list)
+    metrics_reports: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def success_rate(self) -> float:
@@ -56,7 +56,7 @@ class BenchmarkResult:
             return 0.0
         return statistics.stdev(self.execution_times_ms)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert benchmark result to dictionary for reporting"""
         return {
             "test_case": self.test_case,
@@ -70,7 +70,7 @@ class BenchmarkResult:
             "metrics": self.get_aggregated_metrics(),
         }
 
-    def get_aggregated_metrics(self) -> Dict[str, Any]:
+    def get_aggregated_metrics(self) -> dict[str, Any]:
         """Aggregate metrics from all successful runs"""
         if not self.metrics_reports:
             return {}
@@ -96,7 +96,7 @@ class BenchmarkResult:
         throughputs = []
 
         # Task metrics collection
-        task_metrics: Dict[str, Dict[str, List[float]]] = {}
+        task_metrics: dict[str, dict[str, list[float]]] = {}
 
         for report in self.metrics_reports:
             if "resource_metrics" in report:
@@ -279,7 +279,7 @@ class PipelineBenchmarker:
         return result
 
     def _validate_result(
-        self, test_case_name: str, result: Dict[str, Any], expected: Dict[str, Any]
+        self, test_case_name: str, result: dict[str, Any], expected: dict[str, Any]
     ) -> None:
         """
         Validate that the pipeline result matches the expected output.
@@ -304,7 +304,7 @@ class PipelineBenchmarker:
 
     async def run_all_benchmarks(
         self, iterations: int = 3
-    ) -> Dict[str, BenchmarkResult]:
+    ) -> dict[str, BenchmarkResult]:
         """
         Run benchmarks for all test cases.
 
@@ -314,7 +314,7 @@ class PipelineBenchmarker:
         Returns:
             Dictionary mapping test case names to BenchmarkResult objects
         """
-        results: Dict[str, BenchmarkResult] = {}
+        results: dict[str, BenchmarkResult] = {}
 
         for test_case_name in self.test_cases.keys():
             result = await self.run_benchmark(test_case_name, iterations)
@@ -322,7 +322,7 @@ class PipelineBenchmarker:
 
         return results
 
-    def print_benchmark_report(self, results: Dict[str, BenchmarkResult]) -> None:
+    def print_benchmark_report(self, results: dict[str, BenchmarkResult]) -> None:
         """
         Print a formatted report of benchmark results.
 

--- a/src/pipeline_optimization/benchmarks/metrics.py
+++ b/src/pipeline_optimization/benchmarks/metrics.py
@@ -2,7 +2,7 @@ import gc
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import psutil
 
@@ -16,7 +16,7 @@ class TaskMetrics:
     successes: int = 0
     failures: int = 0
     total_execution_time: float = 0.0
-    execution_times: List[float] = field(default_factory=list)
+    execution_times: list[float] = field(default_factory=list)
 
     @property
     def success_rate(self) -> float:
@@ -42,7 +42,7 @@ class MetricsCollector:
     """
 
     def __init__(self) -> None:
-        self.task_metrics: Dict[str, TaskMetrics] = defaultdict(
+        self.task_metrics: dict[str, TaskMetrics] = defaultdict(
             lambda: TaskMetrics("unknown")
         )
         self.pipeline_start_time: Optional[float] = None
@@ -53,12 +53,12 @@ class MetricsCollector:
         # Resource usage metrics
         self.initial_memory: float = 0.0
         self.peak_memory: float = 0.0
-        self.cpu_utilization: List[float] = []
+        self.cpu_utilization: list[float] = []
         # Snapshot CPU times at pipeline start (will use CPU-time delta for avg CPU%)
         self._cpu_start_times = None
 
         # Performance metrics
-        self.throughput_word_per_sec: List[float] = []
+        self.throughput_word_per_sec: list[float] = []
 
     def start_pipeline(self) -> None:
         """Record the start of a pipeline execution and capture initial resource usage"""
@@ -132,7 +132,7 @@ class MetricsCollector:
         else:
             metric.failures += 1
 
-    def get_metrics_report(self) -> Dict[str, Any]:
+    def get_metrics_report(self) -> dict[str, Any]:
         """
         Generate a comprehensive metrics report.
 

--- a/src/pipeline_optimization/cli/compare_benchmarks.py
+++ b/src/pipeline_optimization/cli/compare_benchmarks.py
@@ -12,7 +12,7 @@ import importlib.util
 import json
 import os
 import sys
-from typing import Any, Dict
+from typing import Any
 
 from tabulate import tabulate
 
@@ -54,7 +54,7 @@ def load_orchestrator_from_file(file_path: str) -> Any:
     return module.TaskOrchestrator()
 
 
-def find_orchestrators(compare_dir: str) -> Dict[str, Any]:
+def find_orchestrators(compare_dir: str) -> dict[str, Any]:
     """
     Find all Python files in the specified directory and load their orchestrators.
 
@@ -121,11 +121,11 @@ def format_value(value: float, is_best: bool, format_str: str = "{:.2f}") -> str
 
 
 async def run_benchmarks(
-    orchestrators: Dict[str, Any],
+    orchestrators: dict[str, Any],
     iterations: int = 3,
     test_case: str = "all",
     show_details: bool = False,
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     """
     Run benchmarks for all orchestrators and collect results.
 
@@ -143,7 +143,7 @@ async def run_benchmarks(
         test_cases = json.load(file)
 
     # Prepare results structure
-    all_results: Dict[str, Dict[str, Any]] = {}
+    all_results: dict[str, dict[str, Any]] = {}
 
     # Run benchmarks for each orchestrator
     for name, orchestrator in orchestrators.items():
@@ -173,8 +173,8 @@ async def run_benchmarks(
 
 
 def aggregate_metrics(
-    all_results: Dict[str, Dict[str, Any]],
-) -> Dict[str, Dict[str, Any]]:
+    all_results: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
     """
     Aggregate metrics across all test cases for each orchestrator.
 
@@ -238,7 +238,7 @@ def aggregate_metrics(
     return summary
 
 
-def print_comparison_table(summary: Dict[str, Dict[str, Any]]) -> None:
+def print_comparison_table(summary: dict[str, dict[str, Any]]) -> None:
     """
     Print a side-by-side comparison table of all orchestrators.
 

--- a/src/pipeline_optimization/main.py
+++ b/src/pipeline_optimization/main.py
@@ -2,7 +2,7 @@ import argparse
 import asyncio
 import json
 import time
-from typing import Any, Dict
+from typing import Any
 
 from pipeline_optimization.benchmarks.benchmarker import PipelineBenchmarker
 from pipeline_optimization.benchmarks.metrics import MetricsCollector
@@ -11,7 +11,7 @@ from pipeline_optimization.orchestrator import TaskOrchestrator
 
 async def run_pipeline(
     test_case_name: str,
-    test_case: Dict[str, Any],
+    test_case: dict[str, Any],
     orchestrator: TaskOrchestrator,
 ) -> None:
     """

--- a/src/pipeline_optimization/orchestrator.py
+++ b/src/pipeline_optimization/orchestrator.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import sys
 import time
-from typing import Any, Dict, List
+from typing import Any
 
 from pipeline_optimization.tasks.filter_input_task import filter_input
 from pipeline_optimization.tasks.find_anagrams_task import find_anagrams
@@ -27,7 +27,7 @@ class TaskOrchestrator:
         with open("src/pipeline_optimization/resources/english_dictionary.json") as f:
             self.dictionary = json.load(f)
 
-    async def process_text(self, text_input: str) -> Dict[str, Any]:
+    async def process_text(self, text_input: str) -> dict[str, Any]:
         """
         Process the input text through the pipeline, finding anagrams and
         counting occurrences.
@@ -48,14 +48,14 @@ class TaskOrchestrator:
         words = await get_words(filtered_input)
 
         # Stage 3: Find anagrams for each word
-        all_anagrams: List[str] = []
+        all_anagrams: list[str] = []
         for word in words:
             print(f"Finding anagrams for {word}")
             anagrams = await find_anagrams(word)
             all_anagrams.extend(anagrams)
 
         # Stage 4: Count the anagrams
-        anagram_counts: Dict[str, int] = {}
+        anagram_counts: dict[str, int] = {}
         for anagram in all_anagrams:
             if anagram not in anagram_counts:
                 anagram_counts[anagram] = 0


### PR DESCRIPTION
Swaps deprecated `typing.Dict`/`typing.List` annotations for builtin `dict`/`list` (PEP 585). No behavior change.

Made with [Cursor](https://cursor.com)